### PR TITLE
Specify data and control channel ciphers

### DIFF
--- a/drive/drive.tf
+++ b/drive/drive.tf
@@ -25,7 +25,7 @@ resource "aws_ecs_task_definition" "blink_drive_task" {
 [
   {
     "name": "blink-drive-1",
-    "image": "jerridan/blink-drive:1.0.0",
+    "image": "jerridan/blink-drive:1.0.1",
     "memory": 256,
     "cpu": 256,
     "privileged": true,

--- a/drive/drive.tf
+++ b/drive/drive.tf
@@ -26,8 +26,8 @@ resource "aws_ecs_task_definition" "blink_drive_task" {
   {
     "name": "blink-drive-1",
     "image": "jerridan/blink-drive:1.0.0",
-    "memory": 512,
-    "cpu": 10,
+    "memory": 256,
+    "cpu": 256,
     "privileged": true,
     "portMappings": [
       {

--- a/drive/scripts/ovpn_generate_client_config.sh
+++ b/drive/scripts/ovpn_generate_client_config.sh
@@ -9,7 +9,7 @@ cat >> ${configuration_file} <<EOF
 client
 nobind
 dev ${OVPN_DEVICE}
-remote-cert-tls server
+remote-cert-tls server # Ensure that the host being connected to is a server
 remote ${OVPN_CN} ${OVPN_PORT} ${OVPN_PROTO}
 key-direction 1
 EOF

--- a/drive/scripts/ovpn_generate_client_config.sh
+++ b/drive/scripts/ovpn_generate_client_config.sh
@@ -11,7 +11,6 @@ nobind
 dev ${OVPN_DEVICE}
 remote-cert-tls server # Ensure that the host being connected to is a server
 remote ${OVPN_CN} ${OVPN_PORT} ${OVPN_PROTO}
-key-direction 1
 ncp-ciphers AES-256-GCM:AES-128-GCM:AES-256-CBC # Allowed ciphers for data channel encryption
 EOF
 }
@@ -27,9 +26,9 @@ $(openssl x509 -in ${BLINK_VOLUME}/${CLIENTNAME}.crt)
 <ca>
 $(cat ${BLINK_VOLUME}/ca.crt)
 </ca>
-<tls-auth>
+<tls-crypt>
 $(cat ${BLINK_VOLUME}/ta.key)
-</tls-auth>
+</tls-crypt>
 EOF
 }
 

--- a/drive/scripts/ovpn_generate_client_config.sh
+++ b/drive/scripts/ovpn_generate_client_config.sh
@@ -33,37 +33,6 @@ $(cat ${BLINK_VOLUME}/ta.key)
 EOF
 }
 
-add_config_options() {
-  if [[ -n "${OVPN_MTU}" ]]; then
-    echo "tun-mtu ${OVPN_MTU}" >> ${configuration_file}
-  fi
-
-  if [[ -n "${OVPN_TLS_CIPHER}" ]]; then
-    echo "tls-cipher ${OVPN_TLS_CIPHER}" >> ${configuration_file}
-  fi
-
-  if [[ -n "${OVPN_CIPHER}" ]]; then
-    echo "cipher ${OVPN_CIPHER}" >> ${configuration_file}
-  fi
-
-  if [[ -n "${OVPN_AUTH}" ]]; then
-    echo "auth ${OVPN_AUTH}" >> ${configuration_file}
-  fi
-
-  if [[ -n "${OVPN_OTP_AUTH}" ]]; then
-    echo "auth-user-pass" >> ${configuration_file}
-    echo "auth-nocache" >> ${configuration_file}
-  fi
-
-  if [[ ${OVPN_COMP_LZO} == "1" ]]; then
-    echo "comp-lzo" >> ${configuration_file}
-  fi
-
-  if [[ -n "${OVPN_OTP_AUTH}" ]]; then
-    echo "reneg-sec 0" >> ${configuration_file}
-  fi
-}
-
 copy_client_config_to_s3() {
   aws s3 cp "${configuration_file}" s3://blink-keys/client.ovpn
 }
@@ -104,7 +73,6 @@ if [[ -f "${configuration_file}" ]]; then
 fi
 
 add_basic_ovpn_protocols
-add_config_options
 add_certificates_and_keys
 
 echo "Successfully generated openvpn client config"

--- a/drive/scripts/ovpn_generate_client_config.sh
+++ b/drive/scripts/ovpn_generate_client_config.sh
@@ -12,6 +12,7 @@ dev ${OVPN_DEVICE}
 remote-cert-tls server # Ensure that the host being connected to is a server
 remote ${OVPN_CN} ${OVPN_PORT} ${OVPN_PROTO}
 ncp-ciphers AES-256-GCM:AES-128-GCM:AES-256-CBC # Allowed ciphers for data channel encryption
+auth SHA256 # Algorithm for HMAC-authenticating data and control channel packets
 EOF
 }
 

--- a/drive/scripts/ovpn_generate_client_config.sh
+++ b/drive/scripts/ovpn_generate_client_config.sh
@@ -64,12 +64,6 @@ add_config_options() {
   fi
 }
 
-add_extra_client_config() {
-  for config in "${OVPN_EXTRA_CLIENT_CONFIG[@]}"; do
-    echo "${config}" >> ${configuration_file}
-  done
-}
-
 copy_client_config_to_s3() {
   aws s3 cp "${configuration_file}" s3://blink-keys/client.ovpn
 }
@@ -111,7 +105,6 @@ fi
 
 add_basic_ovpn_protocols
 add_config_options
-add_extra_client_config
 add_certificates_and_keys
 
 echo "Successfully generated openvpn client config"

--- a/drive/scripts/ovpn_generate_client_config.sh
+++ b/drive/scripts/ovpn_generate_client_config.sh
@@ -12,6 +12,7 @@ dev ${OVPN_DEVICE}
 remote-cert-tls server # Ensure that the host being connected to is a server
 remote ${OVPN_CN} ${OVPN_PORT} ${OVPN_PROTO}
 key-direction 1
+ncp-ciphers AES-256-GCM:AES-128-GCM:AES-256-CBC # Allowed ciphers for data channel encryption
 EOF
 }
 

--- a/drive/scripts/ovpn_generate_server_config.sh
+++ b/drive/scripts/ovpn_generate_server_config.sh
@@ -98,6 +98,7 @@ user nobody
 group nogroup
 remote-cert-tls client # Ensure that only hosts with a client certificate may connect
 ncp-ciphers AES-256-GCM:AES-128-GCM:AES-256-CBC # Allowed ciphers for data channel encryption
+auth SHA256 # Algorithm for HMAC-authenticating data and control channel packets
 EOF
 }
 

--- a/drive/scripts/ovpn_generate_server_config.sh
+++ b/drive/scripts/ovpn_generate_server_config.sh
@@ -98,6 +98,7 @@ status /tmp/openvpn-status.log
 user nobody
 group nogroup
 remote-cert-tls client # Ensure that only hosts with a client certificate may connect
+ncp-ciphers AES-256-GCM:AES-128-GCM:AES-256-CBC # Allowed ciphers for data channel encryption
 EOF
 }
 

--- a/drive/scripts/ovpn_generate_server_config.sh
+++ b/drive/scripts/ovpn_generate_server_config.sh
@@ -97,6 +97,7 @@ status /tmp/openvpn-status.log
 
 user nobody
 group nogroup
+remote-cert-tls client # Ensure that only hosts with a client certificate may connect
 EOF
 }
 

--- a/drive/scripts/ovpn_generate_server_config.sh
+++ b/drive/scripts/ovpn_generate_server_config.sh
@@ -83,8 +83,7 @@ key ${BLINK_VOLUME}/${SERVERNAME}.key
 ca ${BLINK_VOLUME}/ca.crt
 cert ${BLINK_VOLUME}/${SERVERNAME}.crt
 dh ${BLINK_VOLUME}/dh.pem
-tls-auth ${BLINK_VOLUME}/ta.key
-key-direction 0
+tls-crypt ${BLINK_VOLUME}/ta.key
 keepalive ${OVPN_KEEPALIVE}
 persist-key
 persist-tun
@@ -158,8 +157,6 @@ OVPN_DEVICEN=0
 OVPN_DISABLE_PUSH_BLOCK_DNS=0
 OVPN_DNS=1
 OVPN_DNS_SERVERS=([0]="8.8.8.8" [1]="8.8.4.4")
-OVPN_EXTRA_CLIENT_CONFIG=()
-OVPN_EXTRA_SERVER_CONFIG=()
 OVPN_FRAGMENT=''
 OVPN_KEEPALIVE="10 60"
 OVPN_MTU=''


### PR DESCRIPTION
- Specifies allowed ciphers for data channel encryption
- Uses `tls-crypt` in place of `tls-auth`
- Uses SHA256 for all data and control packet authentication